### PR TITLE
Align CF token name between workflow and script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/pages-action@v1
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ecc5914225b19722d5af73dac2c69d5b
           projectName: beppesarrstack-net
           directory: docs/.vitepress/dist
@@ -45,5 +45,4 @@ jobs:
       - name: Create deployment status
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          echo "🚀 Site deployed successfully to https://beppesarrstack.net"
-          echo "Build completed at $(date)"
+          echo "🚀 Site deployed successfully to https://beppesarrstack.net"          echo "Build completed at $(date)"

--- a/scripts/cloudflare-deploy.sh
+++ b/scripts/cloudflare-deploy.sh
@@ -147,4 +147,5 @@ main() {
 
 # Run if script is executed directly
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    main "$@"fi
+    main "$@"
+fi


### PR DESCRIPTION
## Summary
- rename Cloudflare Pages secret reference in workflow to `CF_API_TOKEN`
- ensure `cloudflare-deploy.sh` uses the same secret name and fix script footer

## Testing
- `scripts/lint.zsh`

------
https://chatgpt.com/codex/tasks/task_e_686dca1769348322b0f9b5a64680e499