### PR TITLE
Add compose validation workflow

### DIFF
--- a/.github/workflows/compose-test.yml
+++ b/.github/workflows/compose-test.yml
@@ -1,0 +1,47 @@
+name: Docker Compose Validation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  compose-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npx playwright install --with-deps
+
+      - name: Start stack
+        run: docker compose up -d
+
+      - name: Validate services
+        run: node validate-services.js
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-screenshots
+          path: validation-screenshots
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-results
+          path: validation-results.json
+
+      - name: Stop stack
+        if: always()
+        run: docker compose down

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,39 @@
+# 🧪 Local Stack Validation
+
+This guide shows how to spin up the Usenet Media Stack locally and
+run the Playwright-based validation script.
+
+## Requirements
+
+- Docker and Docker Compose
+- Node.js 18+
+
+## Steps
+
+1. Install dependencies:
+
+   ```bash
+   npm ci
+   npx playwright install --with-deps
+   ```
+
+2. Start the stack:
+
+   ```bash
+   docker compose up -d
+   ```
+
+3. Run the validation script:
+
+   ```bash
+   node validate-services.js
+   ```
+
+   Screenshots are saved to `validation-screenshots/` and results to
+   `validation-results.json`.
+
+4. Stop the stack when done:
+
+   ```bash
+   docker compose down
+   ```


### PR DESCRIPTION
## Summary
- add workflow to bring up stack with `docker compose` and run `validate-services.js`
- publish screenshots and JSON results as workflow artifacts
- document local validation steps in `TESTING.md`

## Testing
- `npm ci`
- `npx playwright install --with-deps`
- `node validate-services.js` *(fails: SyntaxError: Unexpected end of input)*

------
https://chatgpt.com/codex/tasks/task_e_686e70b1a31c8322923f4b1d6a349a61